### PR TITLE
Automate past events

### DIFF
--- a/.forestry/front_matter/templates/template-event.yml
+++ b/.forestry/front_matter/templates/template-event.yml
@@ -58,6 +58,10 @@ fields:
   label: Snippet
   description: The snippet is a short introduction that is currently shown on the
     home page.
+- name: youtube_id
+  type: text
+  label: YouTube ID
+  description: The ID of the video. Videos are recordings of the event and uploaded after the event. You can grab the ID from the URL.
 - name: speakers
   type: field_group_list
   fields:

--- a/src/_assets/css/templates/home.css
+++ b/src/_assets/css/templates/home.css
@@ -65,6 +65,18 @@
     top: 72%;
     width: 2rem;
   }
+
+  &.position-05 {
+    left: -8rem;
+    top: -6rem;
+    width: 12rem;
+  }
+
+  &.position-06 {
+    right: -8rem;
+    top: 12rem;
+    width: 12rem;
+  }
 }
 
 @screen sm {

--- a/src/_includes/layout/header.njk
+++ b/src/_includes/layout/header.njk
@@ -1,4 +1,4 @@
-{% set next_event = collections.events[0] %}
+{% set next_event = collections.upcoming_events[0] %}
 
 <div class="bg-gray-light text-black">
   <div class="container py-8">
@@ -11,15 +11,17 @@
           An event-driven community for underrepresented folx to share, listen, and learn.
         </span>
       </div>
-      <div class="hidden md:flex flex-wrap justify-center md:justify-start items-center font-bold">
-        <span class="hidden lg:inline-block lg:mr-2 xl:mr-3">{{ next_event.data.date | formatDate('DATE_MED') }}</span>
-        <span class="hidden lg:inline-block lg:mx-2 xl:mx-3">{{ next_event.data.time }}</span>
-        <span class="hidden xl:inline-block lg:mx-2 xl:mx-3">{{ next_event.data.location }}</span>
-        <span class="hidden lg:inline-block lg:mx-2 xl:mx-3">{{ next_event.data.cost }}</span>
-        <span class="block md:inline-block w-full md:w-auto mt-4 md:mt-0 ml-0 lg:ml-2 xl:ml-3 text-center">
-          {% button label="Register now", url = next_event.url + "#register" %}
-        </span>
-      </div>
+      {% if next_event %}
+        <div class="hidden md:flex flex-wrap justify-center md:justify-start items-center font-bold">
+          <span class="hidden lg:inline-block lg:mr-2 xl:mr-3">{{ next_event.data.date | formatDate('DATE_MED') }}</span>
+          <span class="hidden lg:inline-block lg:mx-2 xl:mx-3">{{ next_event.data.time }}</span>
+          <span class="hidden xl:inline-block lg:mx-2 xl:mx-3">{{ next_event.data.location }}</span>
+          <span class="hidden lg:inline-block lg:mx-2 xl:mx-3">{{ next_event.data.cost }}</span>
+          <span class="block md:inline-block w-full md:w-auto mt-4 md:mt-0 ml-0 lg:ml-2 xl:ml-3 text-center">
+            {% button label="Register now", url = next_event.url + "#register" %}
+          </span>
+        </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/src/_layouts/event.njk
+++ b/src/_layouts/event.njk
@@ -8,33 +8,60 @@
   {# --- Details --- #}
 
   <ul class="pl-0 mb-6">
-    <li class="list-none mb-1">
-      <strong>Date:</strong>
-      <span>{{ date | formatDate('DATE_MED') }}</span>
-    </li>
-    <li class="list-none mb-1">
-      <strong>Time:</strong>
-      <span>{{ time }}</span>
-    </li>
-    <li class="list-none mb-1">
-      <strong>Location:</strong>
-      <span>{{ location }}</span>
-    </li>
-    <li class="list-none mb-1">
-      <strong>Cost:</strong>
-      <span>{{ cost }}</span>
-    </li>
-    <li class="list-none mb-0">
-      <strong>Register:</strong>
-      <a href="#register">Register below</a>
-    </li>
+    {% if date | isFuture %}
+      <li class="list-none mb-1">
+        <strong>Date:</strong>
+        <span>{{ date | formatDate('DATE_MED') }}</span>
+      </li>
+      <li class="list-none mb-1">
+        <strong>Time:</strong>
+        <span>{{ time }}</span>
+      </li>
+      <li class="list-none mb-1">
+        <strong>Location:</strong>
+        <span>{{ location }}</span>
+      </li>
+      <li class="list-none mb-1">
+        <strong>Cost:</strong>
+        <span>{{ cost }}</span>
+      </li>
+      <li class="list-none mb-0">
+        <strong>Register:</strong>
+        <a href="#register">Register below</a>
+      </li>
+    {% else %}
+      <li class="list-none mb-1">
+        <strong>Date:</strong>
+        <span>{{ date | formatDate('DATE_MED') }}</span> (Past Event)
+      </li>
+    {% endif %}
   </ul>
 
-  {# --- Event Description --- #}
 
   <div class="max-w-2xl mb-12">
+    {# --- Event Description --- #}
+
     {% markdown %}{{ body | safe }}{% endmarkdown %}
+
+    {# --- Video --- #}
+
+    {% if youtube_id %}
+      <div class="max-w-xl">
+        <div class="h-0 overflow-hidden relative" style="padding-bottom: 56.25%">
+          <iframe
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/{{ youtube_id }}"
+            class="absolute h-full left-0 top-0 w-full"
+            title="YouTube video player"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen></iframe>
+        </div>
+      </div>
+    {% endif %}
   </div>
+
 
   {# --- Speakers --- #}
 
@@ -76,38 +103,40 @@
 
   {# --- Registration Form --- #}
 
-  <div class="max-w-xl" id="register">
-    <h2>Register to attend this event</h2>
-    <form name="[Registration] {{ title | replace("'", '') }}" method="POST" data-netlify="true" action="/events/thank-you">
+  {% if date | isFuture %}
+    <div class="max-w-xl" id="register">
+      <h2>Register to attend this event</h2>
+      <form name="[Registration] {{ title | replace(`'`, '') }}" method="POST" data-netlify="true" action="/events/thank-you">
 
-      <div class="mb-4">
-        <label class="block mb-1" for="reg--name">Your Name</label>
-        <input class="rounded-md h-12 px-4 py-2 block w-full border" type="text" name="name" id="reg--name" required>
-      </div>
+        <div class="mb-4">
+          <label class="block mb-1" for="reg--name">Your Name</label>
+          <input class="rounded-md h-12 px-4 py-2 block w-full border" type="text" name="name" id="reg--name" required>
+        </div>
 
-      <div class="mb-4">
-        <label class="block mb-1" for="reg--email">Your Email</label>
-        <input class="rounded-md h-12 px-4 py-2 block w-full border" type="email" name="email" id="reg--email" required>
-      </div>
+        <div class="mb-4">
+          <label class="block mb-1" for="reg--email">Your Email</label>
+          <input class="rounded-md h-12 px-4 py-2 block w-full border" type="email" name="email" id="reg--email" required>
+        </div>
 
-    <input
-      type="submit"
-      value="Register!"
-      class="
-        bg-yellow
-        duration-300
-        inline-block
-        no-underline
-        px-8
-        py-3
-        relative
-        rounded-full
-        text-black
-        transition-all
-        component--button
-      ">
-    </form>
-  </div>
+      <input
+        type="submit"
+        value="Register!"
+        class="
+          bg-yellow
+          duration-300
+          inline-block
+          no-underline
+          px-8
+          py-3
+          relative
+          rounded-full
+          text-black
+          transition-all
+          component--button
+        ">
+      </form>
+    </div>
+  {% endif %}
 </main>
 
 {% include "layout/footer.njk" %}

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -33,16 +33,18 @@
         Join us for an evening of storytelling with some of your favorite fellow nerds. We'll laugh, we'll cry. We may even hear a story without any industry jargon!
       </p>
     </div>
-    {% set next_event = collections.events[0] %}
-    <div class="flex flex-wrap justify-center md:justify-start items-center font-bold">
-      <span class="inline-block mr-3">{{ next_event.data.date | formatDate('DATE_MED') }}</span>
-      <span class="inline-block mx-3">{{ next_event.data.time }}</span>
-      <span class="inline-block mx-3">{{ next_event.data.location }}</span>
-      <span class="inline-block mx-3">{{ next_event.data.cost }}</span>
-      <span class="block md:inline-block w-full md:w-auto mt-4 md:mt-0 ml-0 md:ml-3 text-center">
-        {% button label="Register now", url= next_event.url + "#register" %}
-      </span>
-    </div>
+    {% set next_event = collections.upcoming_events[0] %}
+    {% if next_event %}
+      <div class="flex flex-wrap justify-center md:justify-start items-center font-bold">
+        <span class="inline-block mr-3">{{ next_event.data.date | formatDate('DATE_MED') }}</span>
+        <span class="inline-block mx-3">{{ next_event.data.time }}</span>
+        <span class="inline-block mx-3">{{ next_event.data.location }}</span>
+        <span class="inline-block mx-3">{{ next_event.data.cost }}</span>
+        <span class="block md:inline-block w-full md:w-auto mt-4 md:mt-0 ml-0 md:ml-3 text-center">
+          {% button label="Register now", url= next_event.url + "#register" %}
+        </span>
+      </div>
+    {% endif %}
   </div>
 </div>
 
@@ -50,64 +52,73 @@
 
 <div class="py-16 pb-8 lg:pb-16 overflow-x-hidden">
   <div class="container text-center">
-    <span class="inline-block py-1 px-2 bg-gray-light rounded-md text-xs mb-2">Next Event</span>
-    <h2 class="text-4xl mb-4">{{ next_event.data.title }}</h2>
-    <div class="max-w-lg mx-auto mb-4">
-      {% markdown %}{{ next_event.data.snippet }}{% endmarkdown %}
-    </div>
-    <div class="max-w-lg mx-auto mb-8">
-      {% button label="View Details", url=next_event.url, theme="outline" %}
-    </div>
-    <div class="relative">
-      <span class="absolute template--home--squiggles position-01">
-        {% svg "squiggles-01" %}
-      </span>
-      <span class="absolute template--home--squiggles position-02">
-        {% svg "squiggles-02" %}
-      </span>
-      <span class="absolute template--home--squiggles position-03">
-        {% svg "squiggles-03" %}
-      </span>
-      <span class="absolute template--home--squiggles position-04">
-        {% svg "squiggles-03" %}
-      </span>
+    {% if next_event %}
+      <span class="inline-block py-1 px-2 bg-gray-light rounded-md text-xs mb-2">Next Event</span>
+      <h2 class="text-4xl mb-4">{{ next_event.data.title }}</h2>
+      <div class="max-w-lg mx-auto mb-4">
+        {% markdown %}{{ next_event.data.snippet }}{% endmarkdown %}
+      </div>
+      <div class="max-w-lg mx-auto mb-8">
+        {% button label="View Details", url=next_event.url, theme="outline" %}
+      </div>
+      <div class="relative">
+        <span class="absolute template--home--squiggles position-01">
+          {% svg "squiggles-01" %}
+        </span>
+        <span class="absolute template--home--squiggles position-02">
+          {% svg "squiggles-02" %}
+        </span>
+        <span class="absolute template--home--squiggles position-03">
+          {% svg "squiggles-03" %}
+        </span>
+        <span class="absolute template--home--squiggles position-04">
+          {% svg "squiggles-03" %}
+        </span>
 
 
-      {% if next_event.data.speakers.length > 1 %}
-        <h3 class="text-3xl mt-8 mb-4">
-          Featured Speaker{% if next_event.data.speakers.length > 1 %}s{% endif %}
-        </h3>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-{{ next_event.data.speakers.length }}">
-          {% for speaker in next_event.data.speakers %}
-            {% speaker_card
-                image=speaker.image,
-                name=speaker.title,
-                job_title=speaker.job_title,
-                company=speaker.company,
-                social=speaker.social,
-                className="mx-4 mb-8 lg:mb-0 template-home--speaker"
-            %}
-          {% endfor %}
-        </div>
-      {% else %}
-        {% for speaker in next_event.data.speakers %}
-          <div class="template-home--solo-speaker grid gap-4 md:gap-8 max-w-4xl mt-12 text-left mx-auto">
-            <div class="text-center speaker--image mx-auto">
+        {% if next_event.data.speakers.length > 1 %}
+          <h3 class="text-3xl mt-8 mb-4">
+            Featured Speaker{% if next_event.data.speakers.length > 1 %}s{% endif %}
+          </h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-{{ next_event.data.speakers.length }}">
+            {% for speaker in next_event.data.speakers %}
               {% speaker_card
-                    image=speaker.image,
-                    name=speaker.title,
-                    job_title=speaker.job_title,
-                    company=speaker.company,
-                    social=speaker.social
+                  image=speaker.image,
+                  name=speaker.title,
+                  job_title=speaker.job_title,
+                  company=speaker.company,
+                  social=speaker.social,
+                  className="mx-4 mb-8 lg:mb-0 template-home--speaker"
               %}
-            </div>
-            <div>
-              {% markdown %}{{ speaker.body }}{% endmarkdown %}
-            </div>
+            {% endfor %}
           </div>
-        {% endfor %}
-      {% endif %}
-    </div>
+        {% else %}
+          {% for speaker in next_event.data.speakers %}
+            <div class="template-home--solo-speaker grid gap-4 md:gap-8 max-w-4xl mt-12 text-left mx-auto">
+              <div class="text-center speaker--image mx-auto">
+                {% speaker_card
+                      image=speaker.image,
+                      name=speaker.title,
+                      job_title=speaker.job_title,
+                      company=speaker.company,
+                      social=speaker.social
+                %}
+              </div>
+              <div>
+                {% markdown %}{{ speaker.body }}{% endmarkdown %}
+              </div>
+            </div>
+          {% endfor %}
+        {% endif %}
+      </div>
+    {% else %}
+      <p class="text-lg italic">
+        There are no upcoming events at this time.
+      </p>
+      <p class="text-lg italic">
+        <a href="/community">Join the community</a> to receive new event updates.
+      </p>
+    {% endif %}
   </div>
 </div>
 

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -30,7 +30,7 @@
         yours.
       </h1>
       <p class="max-w-md mb-8 mx-auto md:mx-0">
-        Join us for an evening of storytelling with some of your favorite fellow nerds. We'll laugh, we'll cry. We may even hear a story without any industry jargon!
+        Join our events to hear storytelling by some of your favorite fellow nerds. We'll laugh. We'll cry. We may even hear a story without any industry jargon.
       </p>
     </div>
     {% set next_event = collections.upcoming_events[0] %}
@@ -48,7 +48,7 @@
   </div>
 </div>
 
-{# --- Lineup --- #}
+{# --- Next Event --- #}
 
 <div class="py-16 pb-8 lg:pb-16 overflow-x-hidden">
   <div class="container text-center">
@@ -112,12 +112,35 @@
         {% endif %}
       </div>
     {% else %}
-      <p class="text-lg italic">
-        There are no upcoming events at this time.
-      </p>
-      <p class="text-lg italic">
-        <a href="/community">Join the community</a> to receive new event updates.
-      </p>
+      <div class="relative">
+        <span class="absolute template--home--squiggles position-05">
+          {% svg "squiggles-01" %}
+        </span>
+        <span class="absolute template--home--squiggles position-06">
+          {% svg "squiggles-02" %}
+        </span>
+
+        <div class="max-w-2xl mx-auto">
+          <h2 class="text-2xl sm:text-4xl max-w-xl mx-auto mb-4">Stay tuned. We're currently planning our next event</h2>
+          <p class="text-sm sm:text-lg mb-8">
+            In the meantime, watch April's talk with Lauren Celenza,
+            <em>There's a Crack in the Pavement</em>.
+          </p>
+
+          <div class="h-0 overflow-hidden relative" style="padding-bottom: 56.25%">
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/PzqNBsxDIoU"
+              class="absolute h-full left-0 top-0 w-full"
+              title="YouTube video player"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen></iframe>
+            </div>
+
+        </div>
+      </div>
     {% endif %}
   </div>
 </div>

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -50,6 +50,7 @@
 
 <div class="py-16 pb-8 lg:pb-16 overflow-x-hidden">
   <div class="container text-center">
+    <span class="inline-block py-1 px-2 bg-gray-light rounded-md text-xs mb-2">Next Event</span>
     <h2 class="text-4xl mb-4">{{ next_event.data.title }}</h2>
     <div class="max-w-lg mx-auto mb-4">
       {% markdown %}{{ next_event.data.snippet }}{% endmarkdown %}

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -112,6 +112,7 @@
         {% endif %}
       </div>
     {% else %}
+      {% set last_event = collections.shareable_past_events[0] %}
       <div class="relative">
         <span class="absolute template--home--squiggles position-05">
           {% svg "squiggles-01" %}
@@ -123,22 +124,21 @@
         <div class="max-w-2xl mx-auto">
           <h2 class="text-2xl sm:text-4xl max-w-xl mx-auto mb-4">Stay tuned. We're currently planning our next event</h2>
           <p class="text-sm sm:text-lg mb-8">
-            In the meantime, watch April's talk with Lauren Celenza,
-            <em>There's a Crack in the Pavement</em>.
+            In the meantime, here is a video from a recent event:
+            <a href="{{ last_event.url }}"><em>{{ last_event.data.title }}</em></a>.
           </p>
 
           <div class="h-0 overflow-hidden relative" style="padding-bottom: 56.25%">
             <iframe
               width="560"
               height="315"
-              src="https://www.youtube.com/embed/PzqNBsxDIoU"
+              src="https://www.youtube.com/embed/{{ last_event.data.youtube_id }}"
               class="absolute h-full left-0 top-0 w-full"
               title="YouTube video player"
               frameborder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen></iframe>
-            </div>
-
+          </div>
         </div>
       </div>
     {% endif %}

--- a/src/events/theres-a-crack-in-the-pavement.md
+++ b/src/events/theres-a-crack-in-the-pavement.md
@@ -15,6 +15,7 @@ snippet: |-
 
   Controversial for its geographic inaccuracies but lauded for its modern simplicity, the 1972 New York City Subway Map, designed by Massimo Vignelli, was both a work of art and an inaccurate representation of the city. Lauren's story is a reflection of how often art represents its creator.
 layout: event
+youtube_id: PzqNBsxDIoU
 speakers:
 - image: "/website/uploads/speaker-lauren-celenza.png"
   job_title: Design Lead

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,3 @@
 https://unmutedstories-com.netlify.app/ https://www.unmutedstories.com/ 302!
 /events /events/theres-a-crack-in-the-pavement/ 302!
+/slack  https://join.slack.com/t/unmutehq/shared_invite/zt-ota51c29-b3xBxhWXEWSYZpM4KXE61Q

--- a/utils/collections/events.js
+++ b/utils/collections/events.js
@@ -1,4 +1,14 @@
 /**
+ * Collects and returns all events in chronological order.
+ */
+const getAllEvents = (collectionApi) => {
+  return collectionApi
+    .getAll()
+    .filter((item) => item.data.layout === "event")
+    .sort((a, b) => b.date - a.date);
+};
+
+/**
  * Provides a method for adding NJK components.
  *
  * @param {object} eleventyConfig Eleventy's configuration object
@@ -8,11 +18,15 @@ exports.default = (eleventyConfig) => {
    * Creates the "events" collection from the "event" layout.
    */
   eleventyConfig.addCollection("events", (collectionApi) => {
-    const events = collectionApi
-      .getAll()
-      .filter((item) => item.data.layout === "event")
-      .sort((a, b) => b.date - a.date);
-
-    return events;
+    return getAllEvents(collectionApi);
+  });
+  /**
+   * Creates the "upcoming_events" collection by pulling all events and
+   * filtering out those from the past.
+   */
+  eleventyConfig.addCollection("upcoming_events", (collectionApi) => {
+    return getAllEvents(collectionApi)
+      .filter((event) => event.date >= Date.now())
+      .reverse();
   });
 };

--- a/utils/collections/events.js
+++ b/utils/collections/events.js
@@ -29,4 +29,12 @@ exports.default = (eleventyConfig) => {
       .filter((event) => event.date >= Date.now())
       .reverse();
   });
+  /**
+   * Events that have already occurred who have videos.
+   */
+  eleventyConfig.addCollection("shareable_past_events", (collectionApi) => {
+    return getAllEvents(collectionApi).filter(
+      (event) => event.date < Date.now() && event.data.youtube_id
+    );
+  });
 };

--- a/utils/filters/isFuture.js
+++ b/utils/filters/isFuture.js
@@ -1,0 +1,20 @@
+const { DateTime } = require("luxon");
+
+/**
+ * Add a "isFuture" filter to return if a date is in the future.
+ *
+ * @param {object} eleventyConfig Eleventy's configuration object
+ */
+exports.default = (eleventyConfig) => {
+  /**
+   * Return whether the date is in the future.
+   *
+   * Usage: {{ item.date | isFuture }}
+   *
+   * @param {date} date The date to filter.
+   *
+   */
+  eleventyConfig.addFilter("isFuture", (date) => {
+    return new Date(date) > new Date();
+  });
+};


### PR DESCRIPTION
Introduces the following:

- New copy on the home page jumbotron to be more generic, in case there are no upcoming events
- A placeholder in the next event section on home page that pulls in the most recent past event that has a video and shows the title, a link to the detail page, and the video
- Removes registration and upcoming-focused information from event page for past events
- Adds video to events that have a video (this could technically be used for upcoming events, too)
- An "Next Event" badge to the home page
- Add a redirect from `/slack` to our invitation URL (which I've adjusted so it now never expires)